### PR TITLE
Added abiltity to strip out ANSI color escape codes when calculating cell padding

### DIFF
--- a/lib/cli-table/index.js
+++ b/lib/cli-table/index.js
@@ -137,10 +137,21 @@ Table.prototype.toString = function (){
           - (style['padding-right'] || 0)
       , align = options.colAligns[index] || 'left';
 
+    //
+    // For consideration of terminal "color" programs like colors.js,
+    // which can add ANSI escape color codes to strings,
+    // we destyle the ANSI color escape codes for padding calculations.
+    //
+    // see: http://en.wikipedia.org/wiki/ANSI_escape_code
+    //
+    var code = /\u001b\[\d+m/g;
+    var stripped = ("" + str).replace(code,'');
+    length = stripped.length;
+
     return repeat(' ', style['padding-left'] || 0)
          + (length == width ? str :
              (length < width 
-              ? pad(str, width, ' ', align == 'left' ? 'right' : 
+              ? pad(str, ( width + (str.length - stripped.length) ), ' ', align == 'left' ? 'right' :
                   (align == 'middle' ? 'both' : 'left'))
               : (truncater ? truncate(str, width, truncater) : str))
            )


### PR DESCRIPTION
[api]: Added abiltity to strip out ANSI color escape codes when calculating cell padding
[warn]: I did not run tests, please verify code. 
