### PR TITLE
Fixes auto width string

### DIFF
--- a/lib/cli-table/index.js
+++ b/lib/cli-table/index.js
@@ -91,7 +91,7 @@ Table.prototype.toString = function (){
       cells.forEach(function(cell, i){
         var width = typeof cell == 'object' && cell.width != undefined
           ? cell.width 
-          : ((typeof cell == 'object' ? String(cell.text) : String(cell)).length + (style['padding-left'] || 0) + (style['padding-right'] || 0))
+          : ((typeof cell == 'object' ? utils.strlen(cell.text) : utils.strlen(cell)) + (style['padding-left'] || 0) + (style['padding-right'] || 0))
         colWidths[i] = Math.max(colWidths[i] || 0, width || 0);
       });
     });
@@ -131,27 +131,16 @@ Table.prototype.toString = function (){
   // renders a string, by padding it or truncating it
   function string (str, index){
     var str = String(typeof str == 'object' && str.text ? str.text : str)
-      , length = str.length
+      , length = utils.strlen(str)
       , width = colWidths[index]
           - (style['padding-left'] || 0)
           - (style['padding-right'] || 0)
       , align = options.colAligns[index] || 'left';
 
-    //
-    // For consideration of terminal "color" programs like colors.js,
-    // which can add ANSI escape color codes to strings,
-    // we destyle the ANSI color escape codes for padding calculations.
-    //
-    // see: http://en.wikipedia.org/wiki/ANSI_escape_code
-    //
-    var code = /\u001b\[\d+m/g;
-    var stripped = ("" + str).replace(code,'');
-    length = stripped.length;
-
     return repeat(' ', style['padding-left'] || 0)
          + (length == width ? str :
              (length < width 
-              ? pad(str, ( width + (str.length - stripped.length) ), ' ', align == 'left' ? 'right' :
+              ? pad(str, ( width + (str.length - length) ), ' ', align == 'left' ? 'right' :
                   (align == 'middle' ? 'both' : 'left'))
               : (truncater ? truncate(str, width, truncater) : str))
            )

--- a/lib/cli-table/utils.js
+++ b/lib/cli-table/utils.js
@@ -79,3 +79,17 @@ exports.options = function (defaults, opts){
       c[i] = defaults[i];
   return c;
 };
+
+
+//
+// For consideration of terminal "color" programs like colors.js,
+// which can add ANSI escape color codes to strings,
+// we destyle the ANSI color escape codes for padding calculations.
+//
+// see: http://en.wikipedia.org/wiki/ANSI_escape_code
+//
+exports.strlen = function(str){
+  var code = /\u001b\[\d+m/g;
+  var stripped = ("" + str).replace(code,'');
+  return stripped.length;
+}  


### PR DESCRIPTION
Before it mistakenly added columns for other properties on the Array - by cloning it now create the right table.
