### PR TITLE
Update lib/cli-table/utils.js

### DIFF
--- a/lib/cli-table/utils.js
+++ b/lib/cli-table/utils.js
@@ -1,4 +1,3 @@
-
 /**
  * Repeats a string.
  *
@@ -72,16 +71,18 @@ function clone(a){
   return a;
 };
 
-exports.options = function (defaults, opts){
-  if (!opts) opts = {};
-
-  var c = clone(opts);
-  for (var i in defaults)
-    if (!(i in opts))
-      c[i] = defaults[i];
-  return c;
+exports.options = function(defaults, opts) {
+  var c, i, _i, _len, _results;
+  c = clone(opts);
+  _results = [];
+  for (_i = 0, _len = defaults.length; _i < _len; _i++) {
+    i = defaults[_i];
+    if (i && [].__indexOf.call(opts, i) >= 0) {
+      _results.push(c[_i] = i);
+    }
+  }
+  return _results;
 };
-
 
 //
 // For consideration of terminal "color" programs like colors.js,


### PR DESCRIPTION
Because of error

``` /root/tok/node_modules/alfred/node_modules/step/lib/step.js:39
        throw arguments[0];
                       ^
TypeError: Cannot use 'in' operator to search for 'chars' in undefined
    at Object.exports.options (~/node_modules/cli-table/lib/cli-table/utils.js:78:36)
```
