### PR TITLE
Print compact tables with no decorations

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,71 @@ table.push(
 console.log(table.toString());
 ```
 
+### Custom styles
+The ```chars``` property controls how the table is drawn:
+```javascript
+var table = new Table({
+  chars: { 'top': '═' , 'top-mid': '╤' , 'top-left': '╔' , 'top-right': '╗'
+         , 'bottom': '═' , 'bottom-mid': '╧' , 'bottom-left': '╚' , 'bottom-right': '╝'
+         , 'left': '║' , 'left-mid': '╟' , 'mid': '─' , 'mid-mid': '┼'
+         , 'right': '║' , 'right-mid': '╢' , 'middle': '│' }
+});
+
+table.push(
+    ['foo', 'bar', 'baz']
+  , ['frob', 'bar', 'quuz']
+);
+
+console.log(table.toString());
+// Outputs:
+//
+//╔══════╤═════╤══════╗
+//║ foo  │ bar │ baz  ║
+//╟──────┼─────┼──────╢
+//║ frob │ bar │ quuz ║
+//╚══════╧═════╧══════╝
+```
+
+Empty decoration lines will be skipped, to avoid vertical separator rows just
+set the 'mid', 'left-mid', 'mid-mid', 'right-mid' to the empty string:
+```javascript
+var table = new Table({ chars: {'mid': '', 'left-mid': '', 'mid-mid': '', 'right-mid': ''} });
+table.push(
+    ['foo', 'bar', 'baz']
+  , ['frobnicate', 'bar', 'quuz']
+);
+
+console.log(table.toString());
+// Outputs: (note the lack of the horizontal line between rows)
+//┌────────────┬─────┬──────┐
+//│ foo        │ bar │ baz  │
+//│ frobnicate │ bar │ quuz │
+//└────────────┴─────┴──────┘
+```
+
+By setting all chars to empty with the exception of 'middle' being set to a
+single space and by setting padding to zero, it's possible to get the most
+compact layout with no decorations:
+```javascript
+var table = new Table({
+  chars: { 'top': '' , 'top-mid': '' , 'top-left': '' , 'top-right': ''
+         , 'bottom': '' , 'bottom-mid': '' , 'bottom-left': '' , 'bottom-right': ''
+         , 'left': '' , 'left-mid': '' , 'mid': '' , 'mid-mid': ''
+         , 'right': '' , 'right-mid': '' , 'middle': ' ' },
+  style: { 'padding-left': 0, 'padding-right': 0 }
+});
+
+table.push(
+    ['foo', 'bar', 'baz']
+  , ['frobnicate', 'bar', 'quuz']
+);
+
+console.log(table.toString());
+// Outputs:
+//foo        bar baz
+//frobnicate bar quuz
+```
+
 ## Running tests
 
 Clone the repository with all its submodules and run:

--- a/lib/cli-table/index.js
+++ b/lib/cli-table/index.js
@@ -156,7 +156,8 @@ Table.prototype.toString = function (){
                , chars['top-left'] || chars.top
                , chars['top-right'] ||  chars.top
                , chars['top-mid']);
-    ret += l + "\n";
+    if (l)
+      ret += l + "\n";
   };
 
   function generateRow (items, style) {
@@ -221,6 +222,8 @@ Table.prototype.toString = function (){
   };
 
   function applyStyles(styles, subject) {
+    if (!subject)
+      return '';
     styles.forEach(function(style) {
       subject = subject[style];
     });
@@ -262,8 +265,8 @@ Table.prototype.toString = function (){
                      , chars['left-mid']
                      , chars['right-mid']
                      , chars['mid-mid']);
-
-          ret += l + "\n"
+          if (l)
+            ret += l + "\n"
         }
       }
 
@@ -278,7 +281,11 @@ Table.prototype.toString = function (){
              , chars['bottom-left'] || chars.bottom
              , chars['bottom-right'] || chars.bottom
              , chars['bottom-mid']);
-  ret += l;
+  if (l)
+    ret += l;
+  else
+    // trim the last '\n' if we didn't add the bottom decoration
+    ret = ret.slice(0, -1);
 
   return ret;
 };

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -130,11 +130,8 @@ module.exports = {
         , 'bottom-right': '╝'
         , 'left': '║'
         , 'left-mid': '╟'
-        , 'mid': '─'
-        , 'mid-mid': '┼'
         , 'right': '║'
         , 'right-mid': '╢'
-        , 'middle': '│'
       },
       style: {
           head: []
@@ -177,6 +174,75 @@ module.exports = {
       , '│ foo  │ bar │ baz  │'
       , '│ frob │ bar │ quuz │'
       , '└──────┴─────┴──────┘'
+    ];
+
+    table.toString().should.eql(expected.join("\n"));
+  },
+
+  'test compact empty mid line': function (){
+    var table = new Table({
+      chars: {
+          'mid': ''
+        , 'left-mid': ''
+        , 'mid-mid': ''
+        , 'right-mid': ''
+      },
+      style: {
+          head: []
+        , border: []
+      }
+    });
+
+    table.push(
+        ['foo', 'bar', 'baz']
+      , ['frob', 'bar', 'quuz']
+    );
+
+    var expected = [
+        '┌──────┬─────┬──────┐'
+      , '│ foo  │ bar │ baz  │'
+      , '│ frob │ bar │ quuz │'
+      , '└──────┴─────┴──────┘'
+    ];
+
+    table.toString().should.eql(expected.join("\n"));
+  },
+
+  'test decoration lines disabled': function (){
+    var table = new Table({
+      chars: {
+          'top': ''
+        , 'top-mid': ''
+        , 'top-left': ''
+        , 'top-right': ''
+        , 'bottom': ''
+        , 'bottom-mid': ''
+        , 'bottom-left': ''
+        , 'bottom-right': ''
+        , 'left': ''
+        , 'left-mid': ''
+        , 'mid': ''
+        , 'mid-mid': ''
+        , 'right': ''
+        , 'right-mid': ''
+        , 'middle': ' ' // a single space
+      },
+      style: {
+          head: []
+        , border: []
+        , 'padding-left': 0
+        , 'padding-right': 0
+      }
+    });
+
+    table.push(
+        ['foo', 'bar', 'baz']
+      , ['frobnicate', 'bar', 'quuz']
+    );
+
+    var expected = [
+        'foo        bar baz '
+      , 'frobnicate bar quuz'
     ];
 
     table.toString().should.eql(expected.join("\n"));


### PR DESCRIPTION
Hello,
 I wanted to be able to use cli-table to print columned data in a ultra-compact mode with no decorations whatsoever.

To accomplish this, I wrote some patches adding the following capabilities to cli-table:
1. have a vertical cell separator different from the right border
2. completely omit vertical decoration lines if empty, instead of printing '\n'

I've added some test to prevent the most obvious breackage.

Let me know if there's any change you'd like to see applied.

Thanks!
