### PR TITLE
Strip color codes that include ';'

### DIFF
--- a/lib/cli-table/utils.js
+++ b/lib/cli-table/utils.js
@@ -77,7 +77,7 @@ exports.options = options;
 // see: http://en.wikipedia.org/wiki/ANSI_escape_code
 //
 exports.strlen = function(str){
-  var code = /\u001b\[\d+m/g;
+  var code = /\u001b\[(?:\d*;){0,2}\d*m/g;
   var stripped = ("" + str).replace(code,'');
   var split = stripped.split("\n");
   return split.reduce(function (memo, s) { return (s.length > memo) ? s.length : memo }, 0);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -101,16 +101,22 @@ module.exports = {
       style: {head: ['red'], border: ['grey']}
     });
 
+    var off = '\u001b[39m'
+      , red = '\u001b[31m'
+      , orange = '\u001b[38;5;221m'
+      , grey = '\u001b[90m'
+
+      , c256s = orange + 'v0.1' + off;
+
     table.push(
-        ['v0.1', 'rauchg@gmail.com']
+        [c256s, 'rauchg@gmail.com']
     );
 
-    var off = '\u001b[39m', red = '\u001b[31m', grey = '\u001b[90m';
     var expected = [
         grey + '┌──────┬──────────────────┐' + off
       , grey + '│' + off + red + ' Rel  ' + off + grey + '│' + off + red + ' By               ' + off + grey + '│' + off
       , grey + '├──────┼──────────────────┤' + off
-      , grey + '│' + off + ' v0.1 ' + grey + '│' + off + ' rauchg@gmail.com ' + grey + '│' + off
+      , grey + '│' + off + ' ' + c256s + ' ' + grey + '│' + off + ' rauchg@gmail.com ' + grey + '│' + off
       , grey + '└──────┴──────────────────┘' + off
     ];
 


### PR DESCRIPTION
At present using color strings that contain ';' results in very wide columns when relying on auto sizing due to their prefixes. They do not match the existing color-stripping regex.

This PR adds the `;` character to the regex to allow stripping of strings like:

``` js
'\u001b[1;31mlight colors', '\u001b[mreset' and '\u001b[38;5;203m256-bit colors'
```
