### PR TITLE
Fixing global leak of width variable.

### DIFF
--- a/lib/cli-table/index.js
+++ b/lib/cli-table/index.js
@@ -128,7 +128,7 @@ Table.prototype.toString = function (){
   };
 
   function get_width(obj) {
-    return var width = typeof obj == 'object' && obj.width != undefined
+    return typeof obj == 'object' && obj.width != undefined
          ? obj.width
          : ((typeof obj == 'object' ? utils.strlen(obj.text) : utils.strlen(obj)) + (style['padding-left'] || 0) + (style['padding-right'] || 0))
   }


### PR DESCRIPTION
Great module by the way! Our testing suite found that cli-table was leaking a global `width` variable which we tracked down to line 131.  This fixes the global 'width' var being leaked. 
