### PR TITLE
Update colors version to 0.6.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   , "contributors": ["Sonny Michaud <michaud.sonny@gmail.com> (http://github.com/sonnym)"]
   , "keywords": ["cli", "colors", "table"]
   , "dependencies": {
-      "colors": "~0.3"
+      "colors": "0.6.2"
     }
   , "devDependencies": {
       "expresso": "~0.9"


### PR DESCRIPTION
It looks like there's something wrong with `colors@0.3` and `cli-table` works good with `0.6.2`.

```
npm i colors@0.3.0
npm http GET https://registry.npmjs.org/colors/0.3.0
npm http 304 https://registry.npmjs.org/colors/0.3.0
npm http GET http://packages:5984/colors/-/colors-0.3.0.tgz
npm ERR! fetch failed http://packages:5984/colors/-/colors-0.3.0.tgz
npm http GET http://packages:5984/colors/-/colors-0.3.0.tgz
npm ERR! fetch failed http://packages:5984/colors/-/colors-0.3.0.tgz
npm http GET http://packages:5984/colors/-/colors-0.3.0.tgz
npm ERR! fetch failed http://packages:5984/colors/-/colors-0.3.0.tgz
npm ERR! network getaddrinfo ENOTFOUND
npm ERR! network This is most likely not a problem with npm itself
npm ERR! network and is related to network connectivity.
npm ERR! network In most cases you are behind a proxy or have bad network settings.
npm ERR! network
npm ERR! network If you are behind a proxy, please make sure that the
npm ERR! network 'proxy' config is set properly.  See: 'npm help config'

npm ERR! System Darwin 13.0.2
npm ERR! command "node" "/usr/local/bin/npm" "i" "colors@0.3.0"
npm ERR! cwd /Users/tadatuta/tst
npm ERR! node -v v0.10.24
npm ERR! npm -v 1.3.21
npm ERR! syscall getaddrinfo
npm ERR! code ENOTFOUND
npm ERR! errno ENOTFOUND
npm ERR!
npm ERR! Additional logging details can be found in:
npm ERR!     /Users/tadatuta/tst/npm-debug.log
npm ERR! not ok code 0
```
