### PR TITLE
Support colors in individual cells of the table.

### DIFF
--- a/lib/cli-table/index.js
+++ b/lib/cli-table/index.js
@@ -180,7 +180,8 @@ Table.prototype.toString = function (){
 
     // transform array of item strings into structure of cells
     items.forEach(function (item, i) {
-      var contents = item.toString().split("\n").reduce(function (memo, l) {
+      var contents = item.msg || item;
+      contents = contents.toString().split("\n").reduce(function (memo, l) {
         memo.push(string(l, i));
         return memo;
       }, [])
@@ -188,16 +189,19 @@ Table.prototype.toString = function (){
       var height = contents.length;
       if (height > max_height) { max_height = height };
 
-      cells.push({ contents: contents , height: height });
+      //Add the style in the cell in the order of cell style,line style, empty style
+      cells.push({ contents: contents , height: height, style: item.style || style || [] });
     });
 
     // transform vertical cells into horizontal lines
     var lines = new Array(max_height);
     cells.forEach(function (cell, i) {
       cell.contents.forEach(function (line, j) {
+        var styleToApply = cell.style;
         if (!lines[j]) { lines[j] = [] };
-        if (style || (first_cell_head && i === 0 && options.style.head)) {
-          line = applyStyles(options.style.head, line)
+        //if first_cell_head is true, use head style for styleToApply
+        if (styleToApply || (first_cell_head && i === 0 && options.style.head, styleToApply = options.style.head)) {
+          line = applyStyles(styleToApply, line);
         }
 
         lines[j].push(line);


### PR DESCRIPTION
There is often need to highlight particular cells in a table. To achieve that there needs to be a way to specify a style for each cell and corresponding logic for it.
To support this, if a cell needs particular style, an object with msg and style properties need to be passed.

Sample:
var Table = require('cli-table');

var table = new Table({
        head: ['Rel', 'Change', 'By', 'When']
      , style: {
            'padding-left': 1
          , 'padding-right': 1
          , head: []
          , border: []
        }
      , colWidths: [6, 21, 25, 17]
    });

table.push([{msg: 'Hi'}, {msg: 'Hello',style: ['blue']}, 'Hi', 'Hi']);

ran npm test to ensure sanity of the build
