### PR TITLE
Adds `repository` field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,4 +16,8 @@
       "test": "make test"
     }
   , "engines": { "node": ">= 0.2.0" }
+  , "repository": {
+    "type": "git",
+    "url": "https://github.com/LearnBoost/cli-table"
+  }
 }


### PR DESCRIPTION
This is because NPM (1.4.13) issues a warning when no `repository` field is present:

```
npm WARN package.json cli-table@0.3.0 No repository field.
```
