### PR TITLE
Add repository field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   , "version": "0.3.0"
   , "author": "Guillermo Rauch <guillermo@learnboost.com>"
   , "contributors": ["Sonny Michaud <michaud.sonny@gmail.com> (http://github.com/sonnym)"]
+  , "repository": {
+      "type": "git",
+      "url": "https://github.com/Automattic/cli-table.git"
+    }
   , "keywords": ["cli", "colors", "table"]
   , "dependencies": {
       "colors": "0.6.2"


### PR DESCRIPTION
It took me forever to locate this repo, since https://www.npmjs.org/package/cli-table doesn't point to it. Republishing the `npm` module will ensure that people can find the repo from the `npm` module.
