### PR TITLE
Fix render() assignment.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -75,7 +75,7 @@ Table.prototype.__defineGetter__('width', function (){
  * @api public
  */
 
-Table.prototype.render
+Table.prototype.render =
 Table.prototype.toString = function (){
   var ret = ''
     , options = this.options

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -41,6 +41,7 @@ module.exports = {
     ];
 
     table.toString().should.eql(expected.join("\n"));
+    table.render().should.eql(expected.join("\n"));
   },
 
   'test width property': function (){


### PR DESCRIPTION
I can only assume someone missed the `=` sign.
Also adds an assertion in the test suite to ensure it operates the same as `toString()`.
