### PR TITLE
fix broken tables caused by incorrectly calculated unicode string length

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,5 +1,12 @@
 
 /**
+ * Module dependencies.
+ */
+
+var stripCombiningMarks = require('strip-combining-marks')
+  , stringLength = require('string-length');
+
+/**
  * Repeats a string.
  *
  * @param {String} char(s)
@@ -77,8 +84,9 @@ exports.options = options;
 // see: http://en.wikipedia.org/wiki/ANSI_escape_code
 //
 exports.strlen = function(str){
-  var code = /\u001b\[(?:\d*;){0,5}\d*m/g;
-  var stripped = ("" + str).replace(code,'');
-  var split = stripped.split("\n");
-  return split.reduce(function (memo, s) { return (s.length > memo) ? s.length : memo }, 0);
+  function _strlen(s) {
+    return stringLength(stripCombiningMarks(s));
+  }
+  var split = ("" + str).split("\n");
+  return split.reduce(function (memo, s) { return (_strlen(s) > memo) ? _strlen(s) : memo }, 0);
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     }
   , "keywords": ["cli", "colors", "table"]
   , "dependencies": {
-      "colors": "1.0.3"
+      "colors": "1.0.3",
+      "strip-combining-marks": "0.1.0",
+      "string-length": "1.0.0"
     }
   , "devDependencies": {
       "expresso": "~0.9"

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -273,5 +273,31 @@ module.exports = {
     ];
 
     table.toString().should.eql(expected.join("\n"));
+  },
+
+  'test unicode string length calculation': function (){
+    var table = new Table({
+      style: {
+          head: []
+        , border: []
+      }
+    });
+
+    table.push(
+        ["x̃"]
+    );
+    table.push(
+        ["𐌢"]
+    );
+
+    var expected = [
+        '┌───┐'
+      , '│ x̃ │'
+      , '├───┤'
+      , '│ 𐌢 │'
+      , '└───┘'
+    ];
+
+    table.toString().should.eql(expected.join("\n"));
   }
 };


### PR DESCRIPTION
Counting the number of characters in unicode strings is [hard](https://mathiasbynens.be/notes/javascript-unicode). This should fix problems with astral symbols and combining marks (e.g. diacritics).
