### PR TITLE
Fix incorrect array check

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -94,7 +94,7 @@ Table.prototype.toString = function (){
 
       all_rows.forEach(function(cells){
         // horizontal (arrays)
-        if (typeof cells === 'object' && cells.length) {
+        if (Array.isArray(cells) && cells.length) {
           extractColumnWidths(cells);
 
         // vertical (objects)
@@ -105,7 +105,7 @@ Table.prototype.toString = function (){
           colWidths[0] = Math.max(colWidths[0] || 0, get_width(header_cell) || 0);
 
           // cross (objects w/ array values)
-          if (typeof value_cell === 'object' && value_cell.length) {
+          if (Array.isArray(value_cell) && value_cell.length) {
             extractColumnWidths(value_cell, 1);
           } else {
             colWidths[1] = Math.max(colWidths[1] || 0, get_width(value_cell) || 0);
@@ -269,7 +269,7 @@ Table.prototype.toString = function (){
         }
       }
 
-      if (cells.hasOwnProperty("length") && !cells.length) {
+      if (Array.isArray(cells) && !cells.length) {
         return
       } else {
         ret += generateRow(cells) + "\n";


### PR DESCRIPTION
`Array.isArray()` is used for checking properties - it's more correct and allows using of `length` and other `Array` method names to be used as keys in data to be rendered.

@Automattic @rauchg This is a blocker of Unitech/PM2#1764, please, review it as soon as possible. 
