### PR TITLE
changes default border to white from grey

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -42,7 +42,7 @@ function Table (options){
           'padding-left': 1
         , 'padding-right': 1
         , head: ['red']
-        , border: ['grey']
+        , border: ['white']
         , compact : false
       }
     , head: []


### PR DESCRIPTION
The grey border draws as the same color as the background color in PuTTY. fixes #98 