### PR TITLE
Replace colors.js with chalk

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,7 @@
  * Module dependencies.
  */
 
-var colors = require('colors/safe')
+var colors = require('chalk')
   , utils = require('./utils')
   , repeat = utils.repeat
   , truncate = utils.truncate

--- a/package.json
+++ b/package.json
@@ -1,26 +1,35 @@
-{   "name": "cli-table"
-  , "description": "Pretty unicode tables for the CLI"
-  , "version": "0.3.1"
-  , "author": "Guillermo Rauch <guillermo@learnboost.com>"
-  , "contributors": ["Sonny Michaud <michaud.sonny@gmail.com> (http://github.com/sonnym)"]
-  , "repository": {
-      "type": "git",
-      "url": "https://github.com/Automattic/cli-table.git"
-    }
-  , "keywords": ["cli", "colors", "table"]
-  , "dependencies": {
-      "colors": "1.0.3"
-    }
-  , "devDependencies": {
-      "expresso": "~0.9"
-    , "should": "~0.6"
-    }
-  , "main": "lib"
-  , "files": [
-      "lib"
-    ]
-  , "scripts": {
-      "test": "make test"
-    }
-  , "engines": { "node": ">= 0.2.0" }
+{
+  "name": "cli-table",
+  "description": "Pretty unicode tables for the CLI",
+  "version": "0.3.1",
+  "author": "Guillermo Rauch <guillermo@learnboost.com>",
+  "contributors": [
+    "Sonny Michaud <michaud.sonny@gmail.com> (http://github.com/sonnym)"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Automattic/cli-table.git"
+  },
+  "keywords": [
+    "cli",
+    "colors",
+    "table"
+  ],
+  "dependencies": {
+    "chalk": "^2.4.1"
+  },
+  "devDependencies": {
+    "expresso": "~0.9",
+    "should": "~0.6"
+  },
+  "main": "lib",
+  "files": [
+    "lib"
+  ],
+  "scripts": {
+    "test": "make test"
+  },
+  "engines": {
+    "node": ">= 0.2.0"
+  }
 }


### PR DESCRIPTION
Chalk is a drop-in replacement for our use-case, but also supports
the bright versions of colors.

Fixes #63