### PR TITLE
Fixed missing comma in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "cli-table",
   "description": "Pretty unicode tables for the CLI",
   "version": "0.3.1",
-  "license": "MIT"
+  "license": "MIT",
   "author": "Guillermo Rauch <guillermo@learnboost.com>",
   "contributors": [
     "Sonny Michaud <michaud.sonny@gmail.com> (http://github.com/sonnym)"


### PR DESCRIPTION
There's a comma missing from `package.json`, making it invalid json. This PR puts it back.