### PR TITLE
Use string-width instead of wcwidth to fix emoji width in tables

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,4 +1,4 @@
-var wcwidth = require('wcwidth');
+var stringWidth = require('string-width');
 
 /**
  * Repeats a string.
@@ -82,7 +82,7 @@ exports.strlen = function(str){
   var stripped = ("" + (str != null ? str : '')).replace(code,'');
   var split = stripped.split("\n");
   return split.reduce(function (memo, s) {
-      var len = wcwidth(s);
+      var len = stringWidth(s);
       return (len > memo) ? len : memo;
   }, 0);
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "dependencies": {
     "chalk": "^2.4.1",
-    "wcwidth": "^1.0.1"
+    "string-width": "^4.2.0"
   },
   "devDependencies": {
     "expresso": "~0.9",


### PR DESCRIPTION
Hello there,
I was just trying to use the tables with emojis and came across the problem that some of them use 2 columns but get calculated as only one column.
This seems to be a problem with the package `wcwidth` as it doesn't take emojis into account.
As the package `string-width` is much more common for doing this calculation, I just swapped them out. Functionality is almost the same

Before:

```
┌───────┐
│ emoji │
├───────┤
│ ❌     │
└───────┘
```

After:

```
┌───────┐
│ emoji │
├───────┤
│ ❌    │
└───────┘
```