### PR TITLE
Raise minimum NodeJS version to 12.13.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 node_js:
-  - "7.5"
+  - "12.13"
   - "lts/*"
   - "node"

--- a/package.json
+++ b/package.json
@@ -35,6 +35,6 @@
     "publish-please": "publish-please --access public"
   },
   "engines": {
-    "node": ">= 7.5.0"
+    "node": ">= 12.13.0"
   }
 }


### PR DESCRIPTION
Current LTS is 12, so let's bump NodeJS up.