### PR TITLE
Add rows option to constructor

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -47,7 +47,13 @@ function Table (options){
       }
     , head: []
   }, options);
-};
+
+  if (options.rows) {
+    for (var i = 0; i < options.rows.length; i++) {
+      this.push(options.rows[i]);
+    }
+  }
+}
 
 /**
  * Inherit from Array.

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -254,4 +254,27 @@ module.exports = {
     table.toString().should.eql(expected.join("\n"));
   },
 
+  'test rows option in constructor': () => {
+    const table = new Table({
+      style: {
+        head: [],
+        border: []
+      },
+      rows: [
+          ['foo', '7 minutes ago']
+        , ['bar', '8 minutes ago']
+      ]
+    });
+
+    const expected = [
+        '┌─────┬───────────────┐'
+      , '│ foo │ 7 minutes ago │'
+      , '├─────┼───────────────┤'
+      , '│ bar │ 8 minutes ago │'
+      , '└─────┴───────────────┘'
+    ];
+
+    table.toString().should.eql(expected.join("\n"));
+  },
+
 };


### PR DESCRIPTION
## Description

Add a `rows` option that allows initialization of rows in the constructor.

This is easier to use for simple tables and a bit more idiomatic of contemporary Javascript.

## Did you include automated tests? ;)

- [x] Test included

## Usage

```js
new Table({
  rows: [
      ['foo', '7 minutes ago']
    , ['bar', '8 minutes ago']
  ]
})
```