### PR TITLE
Add license file and field to package.json

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2010 LearnBoost <dev@learnboost.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "Sonny Michaud <michaud.sonny@gmail.com> (http://github.com/sonnym)",
     "Gabriel Sambarino <gabriel.sambarino@gmail.com> (http://github/chrean)"
   ],
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/Automattic/cli-table.git"


### PR DESCRIPTION
Hey!

In this PR I've added LICENSE file and added a field to package.json describing the license.

It is important because different license-checking tools can't detect the license of this package properly due to absence of those things.

Hope I've made everything correctly and you would be able to publish a new version with those changes! 🐨 