### PR TITLE
Make sure options are not null. Add test

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -48,7 +48,7 @@ function Table (options){
     , head: []
   }, options);
 
-  if (options.rows) {
+  if (options && options.rows) {
     for (var i = 0; i < options.rows.length; i++) {
       this.push(options.rows[i]);
     }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -309,4 +309,9 @@ module.exports = {
     table.toString().should.eql(expected.join("\n"));
   },
 
+  'test table with no options provided in constructor': () => {
+    const table = new Table();
+
+    table.should.exist;
+  },
 };


### PR DESCRIPTION
## Description

Currently, if you try to create a new Table with no options, you will get a crashing error. We need to first do a null check against options.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [X] This change works and has been tested locally (or has an appropriate fallback).
- [X] This change has relevant unit tests.
- [ ] This change has relevant documentation additions / updates (if applicable).

## Deploy Notes

Notes regarding deployment of this PR, if any.

## Steps to Test or Reproduce

1. Create an instance of Table without any options
2. Verify that your table object is not null, and there were no exceptions thrown
