### PR TITLE
Fix strlen crashing when argument is not string

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -81,6 +81,7 @@ exports.options = options;
 // see: http://en.wikipedia.org/wiki/ANSI_escape_code
 //
 exports.strlen = function(str){
+  str = typeof str === 'string' ? str : String(str);
   var stripped = stripAnsi(str);
   var split = stripped.split("\n");
   return split.reduce(function (memo, s) { return (s.length > memo) ? s.length : memo }, 0);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "cli-table",
-  "version": "0.3.8",
+  "version": "0.3.9-dev",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cli-table",
-      "version": "0.3.8",
+      "version": "0.3.9-dev",
+      "license": "MIT",
       "dependencies": {
         "colors": "1.0.3",
         "strip-ansi": "^6.0.1"

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -1,0 +1,21 @@
+/**
+ * Module requirements.
+ */
+
+require('should');
+
+var { strlen } = require('../lib/utils');
+
+/**
+ * Tests.
+ */
+
+
+ module.exports = {
+    'test strlen with string argument': function() {
+        strlen('hello\nme').should.equal(5);
+    },
+    'test strlen with number argument': function() {
+        strlen(5).should.equal(1);
+    },
+ }


### PR DESCRIPTION
## Description

0.3.7 introduce a breaking change where the strlen util function can no longer handle non-string arguments. It attempts to pass the argument to `stripAnsi` regardless which returns null. It then attempts .split, which crashes when str is not a string. This should ensure that does not happen by always guaranteeing the argument to `stripAnsi` is a string. This will resolve #152 and #157 

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change has relevant unit tests.
- [x] This change has relevant documentation additions / updates (if applicable).

## Deploy Notes

Notes regarding deployment of this PR, if any.

## Steps to Test or Reproduce

Added unit tests to confirm the `strlen` function can handle both string and non-string arguments, which was causing the error previously

Example:

1. Pull down PR.
2. Run tests
3. Verify they all pass
