### PR TITLE
Fix when colWidths option is undefined, it cause an error

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -89,7 +89,7 @@ Table.prototype.toString = function (){
     , head = options.head
     , chars = options.chars
     , truncater = options.truncate
-      , colWidths = options.colWidths || new Array(this.head.length)
+      , colWidths = options.colWidths || new Array(head.length)
       , totalWidth = 0;
 
     if (!head.length && !this.length) return '';


### PR DESCRIPTION
## Description

when the colWidths option is undefined, it cause an error

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change has relevant unit tests.
- [ ] This change has relevant documentation additions / updates (if applicable).

## Deploy Notes

Notes regarding deployment of this PR, if any.

## Steps to Test or Reproduce

Outline the steps to test and verify the PR here.

Example:

1. Pull down PR.
2. new Table() and Pass parameters， the  colWidths value is undefined
3. it cannot cause an error.
