### PR TITLE
Return license field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,1 +1,28 @@
-{"name":"cli-table","description":"Pretty unicode tables for the CLI","version":"0.3.11-dev","author":"Guillermo Rauch <guillermo@learnboost.com>","contributors":["Sonny Michaud <michaud.sonny@gmail.com> (http://github.com/sonnym)"],"repository":{"type":"git","url":"https://github.com/Automattic/cli-table.git"},"keywords":["cli","colors","table"],"dependencies":{"colors":"1.0.3"},"devDependencies":{"expresso":"~0.9","should":"~0.6"},"main":"lib","files":["lib"],"scripts":{"test":"make test"},"engines":{"node":">= 0.2.0"}}
+{
+  "name": "cli-table",
+  "description": "Pretty unicode tables for the CLI",
+  "version": "0.3.11-dev",
+  "author": "Guillermo Rauch <guillermo@learnboost.com>",
+  "contributors": ["Sonny Michaud <michaud.sonny@gmail.com> (http://github.com/sonnym)"],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Automattic/cli-table.git"
+  },
+  "keywords": ["cli", "colors", "table"],
+  "dependencies": {
+    "colors": "1.0.3"
+  },
+  "devDependencies": {
+    "expresso": "~0.9",
+    "should": "~0.6"
+  },
+  "main": "lib",
+  "files": ["lib"],
+  "scripts": {
+    "test": "make test"
+  },
+  "engines": {
+    "node": ">= 0.2.0"
+  }
+}


### PR DESCRIPTION
## Description

I'm returning the license field to package.json as we discussed in #150.

I've also beautified the package.json. Not sure that it was needed though, maybe it was necessary to keep it as a one line.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change has relevant unit tests.
- [ ] This change has relevant documentation additions / updates (if applicable).

(I have not run tests, so it would be fair not to check those checkboxes.)

## Deploy Notes

Nothing here.

## Steps to Test or Reproduce

Example:

1. Pull down PR.
2. Open package.json.
3. Verify the license field is there.