### PR TITLE
fix: [security] Replace colors with chalk.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ your node.js scripts.
 
 - Customizable characters that constitute the table.
 - Color/background styling in the header through
-  [colors.js](http://github.com/marak/colors.js)
+  [chalk](https://github.com/chalk/chalk)
 - Column width customization
 - Text truncation based on predefined widths
 - Text alignment (left, right, center)
@@ -19,7 +19,7 @@ your node.js scripts.
 
 ## Installation
 
-```bash    
+```bash
 npm install cli-table
 ```
 
@@ -166,7 +166,7 @@ $ make test
 
 [![huntr](https://cdn.huntr.dev/huntr_security_badge_mono.svg)](https://huntr.dev)
 
-## License 
+## License
 
 (The MIT License)
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,7 @@
  * Module dependencies.
  */
 
-var colors = require('colors/safe')
+var chalk = require('chalk')
   , utils = require('./utils')
   , repeat = utils.repeat
   , truncate = utils.truncate
@@ -230,7 +230,7 @@ Table.prototype.toString = function (){
     if (!subject)
       return '';
     styles.forEach(function(style) {
-      subject = colors[style](subject);
+      subject = chalk[style](subject);
     });
     return subject;
   };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -72,7 +72,7 @@ function options(defaults, opts) {
 exports.options = options;
 
 //
-// For consideration of terminal "color" programs like colors.js,
+// For consideration of terminal "color" programs like chalk,
 // which can add ANSI escape color codes to strings,
 // we destyle the ANSI color escape codes for padding calculations.
 //

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "cli-table",
-  "version": "0.3.11",
+  "version": "0.3.11-dev",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cli-table",
-      "version": "0.3.11",
+      "version": "0.3.11-dev",
+      "license": "MIT",
       "dependencies": {
-        "colors": "1.0.3"
+        "chalk": "^4.1.2"
       },
       "devDependencies": {
         "expresso": "~0.9",
@@ -18,13 +19,50 @@
         "node": ">= 0.2.0"
       }
     },
-    "node_modules/colors": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-      "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
       "engines": {
-        "node": ">=0.1.90"
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/expresso": {
       "version": "0.9.2",
@@ -40,6 +78,14 @@
         "node": "*"
       }
     },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/should": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/should/-/should-0.6.3.tgz",
@@ -48,13 +94,49 @@
       "engines": {
         "node": ">= 0.2.0"
       }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     }
   },
   "dependencies": {
-    "colors": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-      "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
+    "ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "requires": {
+        "color-convert": "^2.0.1"
+      }
+    },
+    "chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "requires": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      }
+    },
+    "color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "requires": {
+        "color-name": "~1.1.4"
+      }
+    },
+    "color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "expresso": {
       "version": "0.9.2",
@@ -62,11 +144,24 @@
       "integrity": "sha1-F3smCQisrr5F7hbd90SVo/VYYug=",
       "dev": true
     },
+    "has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+    },
     "should": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/should/-/should-0.6.3.tgz",
       "integrity": "sha1-1LVTNciQjzpsR5cLaH91A3Ks3HM=",
       "dev": true
+    },
+    "supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "requires": {
+        "has-flag": "^4.0.0"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "keywords": ["cli", "colors", "table"],
   "dependencies": {
-    "colors": "1.0.3"
+    "chalk": "^4.1.2"
   },
   "devDependencies": {
     "expresso": "~0.9",


### PR DESCRIPTION
## Description

This replaces the `colors` library with `chalk` after the author of colors added an [infinite loop](https://news.ycombinator.com/item?id=29851065) to colors/lib/index.js as a protest.

cli-table is actually already safe, because it had colors.js pinned to an old version, but I'm doing my best to remove the author's code from popular packages because it makes it easier to audit my toolchain.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change has relevant unit tests.
- [x] This change has relevant documentation additions / updates (if applicable).

## Steps to Test or Reproduce

Existing color test cases are passing.