### PR TITLE
Update colors to maintained version

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ your node.js scripts.
 
 - Customizable characters that constitute the table.
 - Color/background styling in the header through
-  [colors.js](http://github.com/marak/colors.js)
+  [colors.js](http://github.com/DABH/colors.js)
 - Column width customization
 - Text truncation based on predefined widths
 - Text alignment (left, right, center)

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,7 @@
  * Module dependencies.
  */
 
-var colors = require('colors/safe')
+var colors = require('@colors/colors/safe')
   , utils = require('./utils')
   , repeat = utils.repeat
   , truncate = utils.truncate

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "cli-table",
-  "version": "0.3.11",
+  "version": "0.3.11-dev",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cli-table",
-      "version": "0.3.11",
+      "version": "0.3.11-dev",
+      "license": "MIT",
       "dependencies": {
-        "colors": "1.0.3"
+        "@colors/colors": "1.5.0"
       },
       "devDependencies": {
         "expresso": "~0.9",
@@ -18,10 +19,10 @@
         "node": ">= 0.2.0"
       }
     },
-    "node_modules/colors": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-      "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
+    "node_modules/@colors/colors": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
       "engines": {
         "node": ">=0.1.90"
       }
@@ -51,10 +52,10 @@
     }
   },
   "dependencies": {
-    "colors": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-      "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
+    "@colors/colors": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="
     },
     "expresso": {
       "version": "0.9.2",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "keywords": ["cli", "colors", "table"],
   "dependencies": {
-    "colors": "1.0.3"
+    "@colors/colors": "1.5.0"
   },
   "devDependencies": {
     "expresso": "~0.9",


### PR DESCRIPTION
Per https://github.com/Marak/colors.js/issues/340, the colors package on which cli-table depends has been migrated to @colors/colors. This PR performs the (very simple) migration. Thanks for your help with getting this into the next release, and let me know if you need any help with getting this fix out or other maintenance tasks.