### PR TITLE
Don't use __proto__

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -59,7 +59,7 @@ function Table (options){
  * Inherit from Array.
  */
 
-Table.prototype.__proto__ = Array.prototype;
+Object.setPrototypeOf(Table.prototype, Array.prototype);
 
 /**
  * Width getter


### PR DESCRIPTION
This makes the library work in Deno, and in Node with `--disable-proto`.
